### PR TITLE
ci: update NuGet publish workflow

### DIFF
--- a/.github/workflows/nuget_deploy.yml
+++ b/.github/workflows/nuget_deploy.yml
@@ -14,10 +14,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 3.1.x
-      # Publish
-      - name: publish on version change
-        id: publish_nuget
-        uses: brandedoutcast/publish-nuget@v2
-        with:
-          PROJECT_FILE_PATH: src/OneSignalApi/OneSignalApi.csproj
-          NUGET_KEY: ${{secrets.NUGET_API_KEY}}
+      - name: Build and Pack
+        run: |
+          dotnet restore
+          dotnet build --configuration Release --no-restore
+          dotnet pack src/OneSignalApi/OneSignalApi.csproj --configuration Release --no-build --output nupkgs
+      - name: Publish to NuGet
+        run: dotnet nuget push nupkgs/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json


### PR DESCRIPTION
# Description
## One Line Summary

Replaces the brandedoutcase/publish-nuget action with native dotnet CLI commands as the project is no longer supported

## Details

### Motivation

To potentially fix issues with the `nuget_deploy` workflow failing at the publish step.

# Testing

## Manual testing
**REQUIRED -** Explain what scenarios were tested and the environment.


# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.