### PR TITLE
ci: add `workflow_dispatch` trigger

### DIFF
--- a/.github/workflows/nuget_deploy.yml
+++ b/.github/workflows/nuget_deploy.yml
@@ -3,6 +3,7 @@ name: NuGet Publish
 on:
   release:
     types: [created]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
# Description
## One Line Summary

Follow-up to #56 to allow the `nuget_deploy` action to be kicked-off manually

## Details

### Motivation
The action is only started when a new GitHub release is published, but can't be started again if an issue occurs.

# Testing

## Manual testing
**REQUIRED -** Explain what scenarios were tested and the environment.


# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.