### PR TITLE
ci: upgrade dotnet version from 3 to 8

### DIFF
--- a/.github/workflows/nuget_deploy.yml
+++ b/.github/workflows/nuget_deploy.yml
@@ -11,14 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Install SSL dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y libssl-dev
       - name: Setup dotnet
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 3.1.x
+          dotnet-version: 8.x
       - name: Build and Pack
         run: |
           dotnet restore


### PR DESCRIPTION
# Description
## One Line Summary
Upgrade the local version of dotnet used in our `nuget_deploy` workflow. Follow up to #58 #57 #56 

## Details
This primarily fixes the issue where the workflow failed with an error: "no usable version of libssl was found". Newer Ubuntu versions included an upgraded OpenSSL to version 3.0, which are not supported by dotnet versions 5 and older (see [this post](https://stackoverflow.com/a/72836925)). Therefore, we can upgrade the local version of dotnet to one that does support this version of OpenSSL. This has the added benefit of using a more up-to-date LTS version of dotnet as v3.1 reached [EOL](https://dotnet.microsoft.com/en-us/download/dotnet) at the end of 2022.

### Motivation
The `nuget_deploy` workflow is currently failing.

# Testing

## Manual testing
Manually tested on the `cd-fix-libssl` branch (with the `Publish to NuGet` step commented out)

# Checklist
## Overview
   - [ ] I have filled out all **REQUIRED** sections above
   - [ ] PR does one thing
     - If it is hard to explain how any codes changes are related to each other then it most likely needs to be more than one PR
   - [ ] Any Public API changes are explained in the PR details and conform to existing APIs

## Testing
   - [ ] I have personally tested this on my device, or explained why that is not possible

## Final pass
   - [ ] Code is as readable as possible.
      - Simplify with less code, followed by splitting up code into well named functions and variables, followed by adding comments to the code.
   - [ ] I have reviewed this PR myself, ensuring it meets each checklist item
      - WIP (Work In Progress) is ok, but explain what is still in progress and what you would like feedback on. Start the PR title with "WIP" to indicate this.