### PR TITLE
feat: add v5.5.0 package updates

### DIFF
--- a/src/OneSignalApi/Client/ApiClient.cs
+++ b/src/OneSignalApi/Client/ApiClient.cs
@@ -274,14 +274,13 @@ namespace OneSignalApi.Client
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
             var clientOptions = new RestClientOptions(baseUrl)
             {
-                Timeout = configuration.Timeout,
+                Timeout = configuration.Timeout > 0 ? TimeSpan.FromMilliseconds(configuration.Timeout) : (TimeSpan?)null,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 ClientCertificates = configuration.ClientCertificates
             };
 
-            var client = new RestClient(clientOptions);
-            client.UseNewtonsoftJson();
+            var client = new RestClient(clientOptions, configureSerialization: s => s.UseNewtonsoftJson());
 
             InterceptRequest(req);
 
@@ -290,7 +289,7 @@ namespace OneSignalApi.Client
             {
                 var policy = RetryConfiguration.RetryPolicy;
                 var policyResult = policy.ExecuteAndCapture(() => client.Execute<T>(req));
-                response = (policyResult.Outcome == OutcomeType.Successful) ? (RestResponse<T>)policyResult.Result : new RestResponse<T>();
+                response = (policyResult.Outcome == OutcomeType.Successful) ? (RestResponse<T>)policyResult.Result : new RestResponse<T>(req);
                 if (policyResult.Outcome != OutcomeType.Successful)
                 {
                     response.ErrorException = policyResult.FinalException;
@@ -331,14 +330,13 @@ namespace OneSignalApi.Client
             var baseUrl = configuration.GetOperationServerUrl(options.Operation, options.OperationIndex) ?? _baseUrl;
             var clientOptions = new RestClientOptions(baseUrl)
             {
-                Timeout = configuration.Timeout,
+                Timeout = configuration.Timeout > 0 ? TimeSpan.FromMilliseconds(configuration.Timeout) : (TimeSpan?)null,
                 Proxy = configuration.Proxy,
                 UserAgent = configuration.UserAgent,
                 ClientCertificates = configuration.ClientCertificates
             };
 
-            var client = new RestClient(clientOptions);
-            client.UseNewtonsoftJson();
+            var client = new RestClient(clientOptions, configureSerialization: s => s.UseNewtonsoftJson());
 
             InterceptRequest(req);
 
@@ -347,7 +345,7 @@ namespace OneSignalApi.Client
             {
                 var policy = RetryConfiguration.AsyncRetryPolicy;
                 var policyResult = await policy.ExecuteAndCaptureAsync(async (ct) => await client.ExecuteAsync<T>(req, ct), cancellationToken).ConfigureAwait(false);
-                response = (policyResult.Outcome == OutcomeType.Successful) ? (RestResponse<T>)policyResult.Result : new RestResponse<T>();
+                response = (policyResult.Outcome == OutcomeType.Successful) ? (RestResponse<T>)policyResult.Result : new RestResponse<T>(req);
                 if (policyResult.Outcome != OutcomeType.Successful)
                 {
                     response.ErrorException = policyResult.FinalException;

--- a/src/OneSignalApi/OneSignalApi.csproj
+++ b/src/OneSignalApi/OneSignalApi.csproj
@@ -25,8 +25,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="JsonSubTypes" Version="[1.8.0, 2.0.0)"/>
-    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="[108.0.3,109.0)"/>
-    <PackageReference Include="RestSharp" Version="[108.0.3,109.0)"/>
+    <PackageReference Include="RestSharp.Serializers.NewtonsoftJson" Version="[114.0.0,115.0.0)"/>
+    <PackageReference Include="RestSharp" Version="[114.0.0,115.0.0)"/>
     <PackageReference Include="Polly" Version="[7.2.3, 8.0.0)"/>
     <PackageReference Include="System.ComponentModel.Annotations" Version="[5.0.0, 6.0.0)"/>
   </ItemGroup>


### PR DESCRIPTION
## Release v5.5.0

### 🚀 Features
- feat: add flat create-notification doc examples via vendor extension

### 🐛 Bug Fixes
- fix(dotnet): bump RestSharp to 114.x to resolve CVEs
- fix(api): keep CreateNotificationSuccessResponse.errors polymorphic

### 📚 Docs
- docs(api): notification targeting DX and TypeScript doc pipeline (SDK-4395)

---
_Generated from [OneSignal/api-client-libraries@bc71af6...998e8fe](https://github.com/OneSignal/api-client-libraries/compare/bc71af602529f22c0d442e3b60e585fb0ad14264...998e8fe85c165523503bbab4b4644e88ef9e8f56)._