### PR TITLE
docs: improve DefaultApi.md examples and add common-patterns preamble

### DIFF
--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -50,6 +50,34 @@ Method | HTTP request | Description
 [**ViewTemplates**](DefaultApi.md#viewtemplates) | **GET** /templates | View templates
 
 
+## Common patterns
+
+The per-endpoint examples below illustrate one specific call each. This section covers patterns that apply to most operations.
+
+### Authentication
+
+Every operation requires either a **REST API Key** (App-scoped, used by ~77% of endpoints) or an **Organization API Key** (used by the remaining ~23% — the app-management endpoints `GetApps` / `CreateApp` / `GetApp` / `UpdateApp` / `CopyTemplateToApp`, plus the API-key administration endpoints `ViewApiKeys` / `CreateApiKey` / `DeleteApiKey` / `UpdateApiKey` / `RotateApiKey`). The two are not interchangeable. The "Authorization" row on each endpoint below lists the exact scheme.
+
+### Idempotency
+
+`POST /notifications` accepts a top-level `idempotency_key` (UUIDv4) that the server uses for request dedup within a **30-day window**. Pass a freshly-generated UUID per logical send so that network-level retries are safe. Never reuse a key across distinct sends — the server returns the original response instead of acting on the new payload. The hero `CreateNotification` example below demonstrates the call.
+
+### Error handling
+
+When a request fails, the SDK throws `ApiException`. The HTTP status code is `e.ErrorCode` (int); the parsed error body is `e.ErrorContent` (object — typically a string holding the raw JSON envelope). Most envelopes match `{ "errors": ["..."] }` (an array of strings) but a few endpoints return `{ "errors": [{"code": ..., "title": ..., "meta": {...}}] }` (an array of structured error objects — used by `POST /apps/{app_id}/users` 409 conflict, see `CreateUserConflictResponse`), `{ "errors": "..." }` (string), or `{ "success": false }` (no `errors` field at all). Robust error-handling code should tolerate all four shapes.
+
+### Polymorphic 200 from POST /notifications
+
+`CreateNotificationSuccessResponse` has two distinct shapes that share the same schema; branch on `id`:
+- **Success** — `id` is a non-empty UUID. `errors`, if present, is an object keyed by recipient-identifier type (`invalid_player_ids`, `invalid_external_user_ids`, `invalid_aliases`, ...) listing recipients that were skipped (partial-success path).
+- **No-send** — `id` is the empty string `""`. `errors` is a string array with the sentinel reason, typically `["All included players are not subscribed"]`.
+
+The hero `CreateNotification` example below demonstrates the branch pattern explicitly.
+
+### Targeting users by External ID
+
+Set `include_aliases.external_id` to a list of External IDs and set `target_channel` to `push` / `email` / `sms`. The alias label must be the literal string `external_id` — camelCase variants such as `externalId` are silently ignored and yield zero recipients. **Do not confuse** this with the deprecated top-level `external_id` notification field — a separate correlation/idempotency field with its own 30-day dedup keyspace (parallel to `idempotency_key`, not an alias) and no targeting effect.
+
 <a name="cancelnotification"></a>
 # **CancelNotification**
 > GenericSuccessBoolResponse CancelNotification (string appId, string notificationId)
@@ -78,8 +106,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var notificationId = "notificationId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88";  // string | 
 
             try
             {
@@ -91,6 +119,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.CancelNotification: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -157,8 +186,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var templateId = "templateId_example";  // string | 
-            var appId = "appId_example";  // string | 
+            var templateId = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
             var copyTemplateRequest = new CopyTemplateRequest(); // CopyTemplateRequest | 
 
             try
@@ -171,6 +200,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.CopyTemplateToApp: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -236,9 +266,9 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var aliasLabel = "aliasLabel_example";  // string | 
-            var aliasId = "aliasId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var aliasLabel = "external_id";  // string | 
+            var aliasId = "YOUR_USER_EXTERNAL_ID";  // string | 
             var userIdentityBody = new UserIdentityBody(); // UserIdentityBody | 
 
             try
@@ -250,6 +280,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.CreateAlias: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -319,8 +350,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var subscriptionId = "subscriptionId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51";  // string | 
             var userIdentityBody = new UserIdentityBody(); // UserIdentityBody | 
 
             try
@@ -332,6 +363,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.CreateAliasBySubscription: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -400,7 +432,7 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
             var createApiKeyRequest = new CreateApiKeyRequest(); // CreateApiKeyRequest | 
 
             try
@@ -413,6 +445,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.CreateApiKey: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -489,6 +522,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.CreateApp: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -553,7 +587,7 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | Your OneSignal App ID in UUID v4 format.
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | Your OneSignal App ID in UUID v4 format.
             var customEventsRequest = new CustomEventsRequest(); // CustomEventsRequest | 
 
             try
@@ -566,6 +600,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.CreateCustomEvents: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -614,6 +649,7 @@ Sends notifications to your users.  **Target by External ID (push example):** se
 
 ### Example
 ```csharp
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using OneSignalApi.Api;
@@ -640,18 +676,42 @@ namespace Example
                 {
                     { "external_id", new List<string> { "YOUR_USER_EXTERNAL_ID" } }
                 },
-                TargetChannel = Notification.TargetChannelEnum.Push
+                TargetChannel = Notification.TargetChannelEnum.Push,
+                // Idempotency key: a client-generated UUID that lets you safely retry on
+                // network failure. If two requests arrive with the same key inside the
+                // 30-day window, only the first is sent and the second returns the original
+                // response. Use Guid.NewGuid() — DO NOT reuse keys across logically distinct
+                // sends.
+                IdempotencyKey = Guid.NewGuid().ToString()
             };
 
             try
             {
                 CreateNotificationSuccessResponse result = apiInstance.CreateNotification(notification);
-                Debug.WriteLine(result);
+                // `result.Id` discriminates the two HTTP 200 shapes. An empty string means
+                // no notification was created (e.g. all targets were unreachable / not
+                // subscribed). `result.Errors` is polymorphic: a `List<string>` in the
+                // no-subscribers case, or an object keyed by recipient-identifier type
+                // (`invalid_player_ids`, `invalid_external_user_ids`, `invalid_aliases`, ...)
+                // when the notification WAS created but some recipients were skipped.
+                if (string.IsNullOrEmpty(result.Id))
+                {
+                    Debug.WriteLine("Notification was not sent: " + result.Errors);
+                }
+                else if (result.Errors != null)
+                {
+                    Debug.WriteLine("Notification created: " + result.Id + " (partial failures: " + result.Errors + ")");
+                }
+                else
+                {
+                    Debug.WriteLine("Notification created: " + result.Id);
+                }
             }
             catch (ApiException e)
             {
                 Debug.Print("Exception when calling DefaultApi.CreateNotification: " + e.Message);
                 Debug.Print("Status Code: " + e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -716,7 +776,7 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | The OneSignal App ID for your app.  Available in Keys & IDs.
             var segment = new Segment(); // Segment |  (optional) 
 
             try
@@ -729,6 +789,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.CreateSegment: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -795,9 +856,9 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var aliasLabel = "aliasLabel_example";  // string | 
-            var aliasId = "aliasId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var aliasLabel = "external_id";  // string | 
+            var aliasId = "YOUR_USER_EXTERNAL_ID";  // string | 
             var subscriptionBody = new SubscriptionBody(); // SubscriptionBody | 
 
             try
@@ -809,6 +870,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.CreateSubscription: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -891,6 +953,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.CreateTemplate: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -955,7 +1018,7 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
             var user = new User(); // User | 
 
             try
@@ -967,6 +1030,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.CreateUser: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1035,10 +1099,10 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var aliasLabel = "aliasLabel_example";  // string | 
-            var aliasId = "aliasId_example";  // string | 
-            var aliasLabelToDelete = "aliasLabelToDelete_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var aliasLabel = "external_id";  // string | 
+            var aliasId = "YOUR_USER_EXTERNAL_ID";  // string | 
+            var aliasLabelToDelete = "external_id";  // string | 
 
             try
             {
@@ -1049,6 +1113,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.DeleteAlias: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1118,8 +1183,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var tokenId = "tokenId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var tokenId = "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff";  // string | 
 
             try
             {
@@ -1131,6 +1196,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.DeleteApiKey: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1195,8 +1261,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | The OneSignal App ID for your app.  Available in Keys & IDs.
-            var segmentId = "segmentId_example";  // string | The segment_id can be found in the URL of the segment when viewing it in the dashboard.
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+            var segmentId = "d6c5a3e1-9f17-44a1-9d10-7c0e4a2b1c8e";  // string | The segment_id can be found in the URL of the segment when viewing it in the dashboard.
 
             try
             {
@@ -1208,6 +1274,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.DeleteSegment: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1274,8 +1341,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var subscriptionId = "subscriptionId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51";  // string | 
 
             try
             {
@@ -1285,6 +1352,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.DeleteSubscription: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1352,8 +1420,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var templateId = "templateId_example";  // string | 
-            var appId = "appId_example";  // string | 
+            var templateId = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
 
             try
             {
@@ -1365,6 +1433,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.DeleteTemplate: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1430,9 +1499,9 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var aliasLabel = "aliasLabel_example";  // string | 
-            var aliasId = "aliasId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var aliasLabel = "external_id";  // string | 
+            var aliasId = "YOUR_USER_EXTERNAL_ID";  // string | 
 
             try
             {
@@ -1442,6 +1511,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.DeleteUser: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1509,8 +1579,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var notificationId = "notificationId_example";  // string | The ID of the notification to export events from.
-            var appId = "appId_example";  // string | The ID of the app that the notification belongs to.
+            var notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88";  // string | The ID of the notification to export events from.
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | The ID of the app that the notification belongs to.
 
             try
             {
@@ -1522,6 +1592,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.ExportEvents: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1588,7 +1659,7 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | The app ID that you want to export devices from
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | The app ID that you want to export devices from
             var exportSubscriptionsRequestBody = new ExportSubscriptionsRequestBody(); // ExportSubscriptionsRequestBody |  (optional) 
 
             try
@@ -1601,6 +1672,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.ExportSubscriptions: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1666,9 +1738,9 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var aliasLabel = "aliasLabel_example";  // string | 
-            var aliasId = "aliasId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var aliasLabel = "external_id";  // string | 
+            var aliasId = "YOUR_USER_EXTERNAL_ID";  // string | 
 
             try
             {
@@ -1679,6 +1751,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.GetAliases: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1746,8 +1819,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var subscriptionId = "subscriptionId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51";  // string | 
 
             try
             {
@@ -1758,6 +1831,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.GetAliasesBySubscription: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1823,7 +1897,7 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | An app id
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | An app id
 
             try
             {
@@ -1835,6 +1909,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.GetApp: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1910,6 +1985,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.GetApps: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -1971,8 +2047,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var notificationId = "notificationId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88";  // string | 
 
             try
             {
@@ -1984,6 +2060,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.GetNotification: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -2050,7 +2127,7 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var notificationId = "notificationId_example";  // string | The \"id\" of the message found in the Notification object
+            var notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88";  // string | The \"id\" of the message found in the Notification object
             var getNotificationHistoryRequestBody = new GetNotificationHistoryRequestBody(); // GetNotificationHistoryRequestBody | 
 
             try
@@ -2063,6 +2140,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.GetNotificationHistory: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -2129,9 +2207,9 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | The app ID that you want to view notifications from
-            var limit = 56;  // int? | How many notifications to return.  Max is 50.  Default is 50. (optional) 
-            var offset = 56;  // int? | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional) 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | The app ID that you want to view notifications from
+            var limit = 10;  // int? | How many notifications to return.  Max is 50.  Default is 50. (optional) 
+            var offset = 0;  // int? | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional) 
             var kind = 0;  // int? | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only  (optional) 
 
             try
@@ -2144,6 +2222,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.GetNotifications: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -2211,12 +2290,12 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | The OneSignal App ID for your app.  Available in Keys & IDs.
-            var outcomeNames = "outcomeNames_example";  // string | Required Comma-separated list of names and the value (sum/count) for the returned outcome data. Note: Clicks only support count aggregation. For out-of-the-box OneSignal outcomes such as click and session duration, please use the \"os\" prefix with two underscores. For other outcomes, please use the name specified by the user. Example:os__session_duration.count,os__click.count,CustomOutcomeName.sum 
-            var outcomeNames2 = "outcomeNames_example";  // string | Optional If outcome names contain any commas, then please specify only one value at a time. Example: outcome_names[]=os__click.count&outcome_names[]=Sales, Purchase.count where \"Sales, Purchase\" is the custom outcomes with a comma in the name.  (optional) 
-            var outcomeTimeRange = "outcomeTimeRange_example";  // string | Optional Time range for the returned data. The values can be 1h (for the last 1 hour data), 1d (for the last 1 day data), or 1mo (for the last 1 month data). Default is 1h if the parameter is omitted.  (optional) 
-            var outcomePlatforms = "outcomePlatforms_example";  // string | Optional Platform id. Refer device's platform ids for values. Example: outcome_platform=0 for iOS outcome_platform=7,8 for Safari and Firefox Default is data from all platforms if the parameter is omitted.  (optional) 
-            var outcomeAttribution = "outcomeAttribution_example";  // string | Optional Attribution type for the outcomes. The values can be direct or influenced or unattributed. Example: outcome_attribution=direct Default is total (returns direct+influenced+unattributed) if the parameter is omitted.  (optional) 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+            var outcomeNames = "os__session_duration.count,os__click.count";  // string | Required Comma-separated list of names and the value (sum/count) for the returned outcome data. Note: Clicks only support count aggregation. For out-of-the-box OneSignal outcomes such as click and session duration, please use the \"os\" prefix with two underscores. For other outcomes, please use the name specified by the user. Example:os__session_duration.count,os__click.count,CustomOutcomeName.sum 
+            var outcomeNames2 = "os__session_duration.count";  // string | Optional If outcome names contain any commas, then please specify only one value at a time. Example: outcome_names[]=os__click.count&outcome_names[]=Sales, Purchase.count where \"Sales, Purchase\" is the custom outcomes with a comma in the name.  (optional) 
+            var outcomeTimeRange = "1d";  // string | Optional Time range for the returned data. The values can be 1h (for the last 1 hour data), 1d (for the last 1 day data), or 1mo (for the last 1 month data). Default is 1h if the parameter is omitted.  (optional) 
+            var outcomePlatforms = "0,1";  // string | Optional Platform id. Refer device's platform ids for values. Example: outcome_platform=0 for iOS outcome_platform=7,8 for Safari and Firefox Default is data from all platforms if the parameter is omitted.  (optional) 
+            var outcomeAttribution = "direct";  // string | Optional Attribution type for the outcomes. The values can be direct or influenced or unattributed. Example: outcome_attribution=direct Default is total (returns direct+influenced+unattributed) if the parameter is omitted.  (optional) 
 
             try
             {
@@ -2228,6 +2307,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.GetOutcomes: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -2297,9 +2377,9 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | The OneSignal App ID for your app.  Available in Keys & IDs.
-            var offset = 56;  // int? | Segments are listed in ascending order of created_at date. offset will omit that number of segments from the beginning of the list. Eg offset 5, will remove the 5 earliest created Segments. (optional) 
-            var limit = 56;  // int? | The amount of Segments in the response. Maximum 300. (optional) 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+            var offset = 0;  // int? | Segments are listed in ascending order of created_at date. offset will omit that number of segments from the beginning of the list. Eg offset 5, will remove the 5 earliest created Segments. (optional) 
+            var limit = 10;  // int? | The amount of Segments in the response. Maximum 300. (optional) 
 
             try
             {
@@ -2311,6 +2391,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.GetSegments: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -2377,9 +2458,9 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var aliasLabel = "aliasLabel_example";  // string | 
-            var aliasId = "aliasId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var aliasLabel = "external_id";  // string | 
+            var aliasId = "YOUR_USER_EXTERNAL_ID";  // string | 
 
             try
             {
@@ -2390,6 +2471,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.GetUser: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -2457,8 +2539,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var tokenId = "tokenId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var tokenId = "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff";  // string | 
 
             try
             {
@@ -2470,6 +2552,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.RotateApiKey: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -2534,8 +2617,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | Your OneSignal App ID in UUID v4 format.
-            var activityType = "activityType_example";  // string | The name of the Live Activity defined in your app. This should match the attributes struct used in your app's Live Activity implementation.
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | Your OneSignal App ID in UUID v4 format.
+            var activityType = "order_status";  // string | The name of the Live Activity defined in your app. This should match the attributes struct used in your app's Live Activity implementation.
             var startLiveActivityRequest = new StartLiveActivityRequest(); // StartLiveActivityRequest | 
 
             try
@@ -2548,6 +2631,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.StartLiveActivity: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -2614,8 +2698,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var subscriptionId = "subscriptionId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51";  // string | 
             var transferSubscriptionRequestBody = new TransferSubscriptionRequestBody(); // TransferSubscriptionRequestBody | 
 
             try
@@ -2627,6 +2711,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.TransferSubscription: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -2695,9 +2780,9 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | The OneSignal App ID for your app.  Available in Keys & IDs.
-            var notificationId = "notificationId_example";  // string | The id of the message found in the creation notification POST response, View Notifications GET response, or URL within the Message Report.
-            var token = "token_example";  // string | The unsubscribe token that is generated via liquid syntax in {{subscription.unsubscribe_token}} when personalizing an email.
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+            var notificationId = "b3a0c8bd-3a4c-4b22-9a73-3f1a8c2d1b88";  // string | The id of the message found in the creation notification POST response, View Notifications GET response, or URL within the Message Report.
+            var token = "YOUR_TOKEN_ID";  // string | The unsubscribe token that is generated via liquid syntax in {{subscription.unsubscribe_token}} when personalizing an email.
 
             try
             {
@@ -2709,6 +2794,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.UnsubscribeEmailWithToken: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -2775,8 +2861,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var tokenId = "tokenId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var tokenId = "0aa1b2c3-d4e5-46f7-8899-aabbccddeeff";  // string | 
             var updateApiKeyRequest = new UpdateApiKeyRequest(); // UpdateApiKeyRequest | 
 
             try
@@ -2789,6 +2875,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.UpdateApiKey: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -2854,7 +2941,7 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | An app id
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | An app id
             var app = new App(); // App | 
 
             try
@@ -2867,6 +2954,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.UpdateApp: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -2932,8 +3020,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | The OneSignal App ID for your app.  Available in Keys & IDs.
-            var activityId = "activityId_example";  // string | Live Activity record ID
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | The OneSignal App ID for your app.  Available in Keys & IDs.
+            var activityId = "12345";  // string | Live Activity record ID
             var updateLiveActivityRequest = new UpdateLiveActivityRequest(); // UpdateLiveActivityRequest | 
 
             try
@@ -2946,6 +3034,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.UpdateLiveActivity: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -3012,8 +3101,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var subscriptionId = "subscriptionId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var subscriptionId = "7e4c5b9a-1f60-4d07-9b1a-2e8c8d2cae51";  // string | 
             var subscriptionBody = new SubscriptionBody(); // SubscriptionBody | 
 
             try
@@ -3024,6 +3113,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.UpdateSubscription: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -3092,9 +3182,9 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | Your OneSignal App ID in UUID v4 format.
-            var tokenType = "tokenType_example";  // string | The type of token to use when looking up the subscription. See Subscription Types.
-            var token = "token_example";  // string | The value of the token to lookup by (e.g., email address, phone number).
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | Your OneSignal App ID in UUID v4 format.
+            var tokenType = "Email";  // string | The type of token to use when looking up the subscription. See Subscription Types.
+            var token = "user@example.com";  // string | The value of the token to lookup by (e.g., email address, phone number).
             var subscriptionBody = new SubscriptionBody(); // SubscriptionBody | 
 
             try
@@ -3107,6 +3197,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.UpdateSubscriptionByToken: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -3174,8 +3265,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var templateId = "templateId_example";  // string | 
-            var appId = "appId_example";  // string | 
+            var templateId = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
             var updateTemplateRequest = new UpdateTemplateRequest(); // UpdateTemplateRequest | 
 
             try
@@ -3188,6 +3279,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.UpdateTemplate: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -3253,9 +3345,9 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
-            var aliasLabel = "aliasLabel_example";  // string | 
-            var aliasId = "aliasId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
+            var aliasLabel = "external_id";  // string | 
+            var aliasId = "YOUR_USER_EXTERNAL_ID";  // string | 
             var updateUserRequest = new UpdateUserRequest(); // UpdateUserRequest | 
 
             try
@@ -3267,6 +3359,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.UpdateUser: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -3335,7 +3428,7 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
 
             try
             {
@@ -3347,6 +3440,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.ViewApiKeys: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -3410,8 +3504,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var templateId = "templateId_example";  // string | 
-            var appId = "appId_example";  // string | 
+            var templateId = "e4d3c2b1-a09f-4f1e-8d7c-6b5a4f3e2d1c";  // string | 
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | 
 
             try
             {
@@ -3423,6 +3517,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.ViewTemplate: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }
@@ -3488,8 +3583,8 @@ namespace Example
             config.AccessToken = "YOUR_BEARER_TOKEN";
 
             var apiInstance = new DefaultApi(config);
-            var appId = "appId_example";  // string | Your OneSignal App ID in UUID v4 format.
-            var limit = 50;  // int? | Maximum number of templates. Default and max is 50. (optional)  (default to 50)
+            var appId = "00000000-0000-0000-0000-000000000000";  // string | Your OneSignal App ID in UUID v4 format.
+            var limit = 10;  // int? | Maximum number of templates. Default and max is 50. (optional)  (default to 50)
             var offset = 0;  // int? | Pagination offset. (optional)  (default to 0)
             var channel = "push";  // string | Filter by delivery channel. (optional) 
 
@@ -3503,6 +3598,7 @@ namespace Example
             {
                 Debug.Print("Exception when calling DefaultApi.ViewTemplates: " + e.Message );
                 Debug.Print("Status Code: "+ e.ErrorCode);
+                Debug.Print("Response Body: " + e.ErrorContent);
                 Debug.Print(e.StackTrace);
             }
         }


### PR DESCRIPTION
## Documentation updates

Improvements to the generated `DefaultApi.md` example snippets:

- New common-patterns preamble at the top of `DefaultApi.md` covering authentication coverage, request/response conventions, and the error-envelope shapes consumers should expect to handle.
- Every example snippet now includes an idiomatic `try`/`catch` (or equivalent) that logs the status code and response body, replacing the previous bare exception print.
- The `POST /notifications` hero snippet demonstrates idempotency-key generation for safe retries within the 30-day window.
- The `POST /notifications` snippet now demonstrates polymorphic response handling (Message Sent vs. Message Not Sent) instead of an unsafe single-shape access.
- Spec-level enrichment: every path and query parameter now carries a realistic `example:` value, so generated parameter snippets no longer fall back to `defaultValue` or first-enum-value placeholders.

---
_Generated from [OneSignal/api-client-libraries@3b35d43...6d24a5c](https://github.com/OneSignal/api-client-libraries/compare/3b35d4372e302d390c67858963e63339b93e15ae...6d24a5cc38b06383b22a67c8805228afbe38e2f9)._