### PR TITLE
feat: add v5.8.0 package updates

### DIFF
--- a/docs/CreateNotificationSuccessResponse.md
+++ b/docs/CreateNotificationSuccessResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **string** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). | [optional] 
+**Id** | **string** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly. | [optional] 
 **ExternalId** | **string** | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under &#x60;include_aliases.external_id&#x60;). | [optional] 
 **Errors** | **Object** | Polymorphic field: may be an array of human-readable strings and/or an object (for example with &#x60;invalid_aliases&#x60;, &#x60;invalid_external_user_ids&#x60;, or &#x60;invalid_player_ids&#x60;) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. | [optional] 
 

--- a/src/OneSignalApi/Client/NotificationHelpers.cs
+++ b/src/OneSignalApi/Client/NotificationHelpers.cs
@@ -116,6 +116,33 @@ namespace OneSignalApi.Client
             }
         }
 
+        /// <summary>
+        /// Whether a POST /notifications 200 response is the "message sent"
+        /// branch. POST /notifications returns 200 in two cases that share the
+        /// <see cref="CreateNotificationSuccessResponse"/> shape: a notification
+        /// was created (non-empty <c>Id</c>), or none was (empty <c>Id</c>, with
+        /// <c>Errors</c> carrying the reason). Prefer this guard over inspecting
+        /// <c>Id</c> directly.
+        /// </summary>
+        /// <param name="response">A create-notification success response.</param>
+        /// <returns>True when a notification was created.</returns>
+        public static bool IsMessageSent(CreateNotificationSuccessResponse response)
+        {
+            return response != null && !string.IsNullOrEmpty(response.Id);
+        }
+
+        /// <summary>
+        /// Whether a POST /notifications 200 response is the "message not sent"
+        /// branch -- no notification was created (<c>Id</c> absent or empty);
+        /// inspect <c>Errors</c> for why.
+        /// </summary>
+        /// <param name="response">A create-notification success response.</param>
+        /// <returns>True when no notification was created.</returns>
+        public static bool IsMessageNotSent(CreateNotificationSuccessResponse response)
+        {
+            return !IsMessageSent(response);
+        }
+
         private static string HeaderValue(Multimap<string, string> headers, string name)
         {
             if (headers == null)

--- a/src/OneSignalApi/Model/CreateNotificationSuccessResponse.cs
+++ b/src/OneSignalApi/Model/CreateNotificationSuccessResponse.cs
@@ -35,7 +35,7 @@ namespace OneSignalApi.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="CreateNotificationSuccessResponse" /> class.
         /// </summary>
-        /// <param name="id">Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200)..</param>
+        /// <param name="id">Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly..</param>
         /// <param name="externalId">Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under &#x60;include_aliases.external_id&#x60;)..</param>
         /// <param name="errors">Polymorphic field: may be an array of human-readable strings and/or an object (for example with &#x60;invalid_aliases&#x60;, &#x60;invalid_external_user_ids&#x60;, or &#x60;invalid_player_ids&#x60;) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize..</param>
         public CreateNotificationSuccessResponse(string id = default(string), string externalId = default(string), Object errors = default(Object))
@@ -46,9 +46,9 @@ namespace OneSignalApi.Model
         }
 
         /// <summary>
-        /// Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200).
+        /// Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly.
         /// </summary>
-        /// <value>Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200).</value>
+        /// <value>Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly.</value>
         [DataMember(Name = "id", EmitDefaultValue = false)]
         public string Id { get; set; }
 


### PR DESCRIPTION
## Release v5.8.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] expose createNotificationWithRetry as a client method
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety

### 🐛 Bug Fixes
- fix: [SDK-4438] guard C++/C# errorMessages against non-string title
- fix: [SDK-4438] skip null and non-string items in C# ErrorMessages
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] treat empty title as missing in all error-messages accessors
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...c73114f](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...c73114f026690637dccea57b21ee6f0a1eca5051)._