### PR TITLE
feat: add v5.8.0 package updates

### DIFF
--- a/docs/CreateNotificationSuccessResponse.md
+++ b/docs/CreateNotificationSuccessResponse.md
@@ -4,7 +4,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**Id** | **string** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). | [optional] 
+**Id** | **string** | Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly. | [optional] 
 **ExternalId** | **string** | Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under &#x60;include_aliases.external_id&#x60;). | [optional] 
 **Errors** | **Object** | Polymorphic field: may be an array of human-readable strings and/or an object (for example with &#x60;invalid_aliases&#x60;, &#x60;invalid_external_user_ids&#x60;, or &#x60;invalid_player_ids&#x60;) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize. | [optional] 
 

--- a/docs/DefaultApi.md
+++ b/docs/DefaultApi.md
@@ -165,6 +165,7 @@ Name | Type | Description  | Notes
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -248,6 +249,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -335,6 +337,7 @@ Name | Type | Description  | Notes
 | **404** | Not Found |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -420,6 +423,7 @@ Name | Type | Description  | Notes
 | **404** | Not Found |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -501,6 +505,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -581,6 +586,7 @@ Name | Type | Description  | Notes
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -664,6 +670,7 @@ Name | Type | Description  | Notes
 | **400** | Bad Request |  -  |
 | **401** | Unauthorized |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -832,6 +839,7 @@ Name | Type | Description  | Notes
 | **200** | OK, invalid_aliases, or No Subscribed Players If a message was successfully created, you will get a 200 response with a non-empty &#x60;id&#x60; for the notification. If the 200 response contains &#x60;invalid_aliases&#x60;, that marks devices that exist in the provided app_id but are no longer subscribed. If &#x60;id&#x60; is an empty string, no notification was created: check the &#x60;errors&#x60; array (for example messages such as \&quot;All included players are not subscribed\&quot;) even though HTTP status is still 200. This can happen when alias keys are wrong, External IDs do not resolve to subscribed users, or other validation issues. If no id is returned, then a message was not created and the targeted User IDs do not exist under the provided app_id. Any User IDs sent in the request that do not exist under the specified app_id will be ignored.  |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -915,6 +923,7 @@ Name | Type | Description  | Notes
 | **400** | Bad Request |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -1003,6 +1012,7 @@ Name | Type | Description  | Notes
 | **404** | Not Found |  -  |
 | **409** | Operation is not permitted due to user having the maximum number of subscriptions assigned |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -1083,6 +1093,7 @@ Name | Type | Description  | Notes
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **422** | Unprocessable Entity |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -1180,6 +1191,7 @@ Name | Type | Description  | Notes
 | **400** | Bad Request |  -  |
 | **409** | Multiple User Identity Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -1267,6 +1279,7 @@ Name | Type | Description  | Notes
 | **404** | Not Found |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -1348,6 +1361,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -1431,6 +1445,7 @@ Name | Type | Description  | Notes
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -1513,6 +1528,7 @@ void (empty response body)
 | **404** | Not Found |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -1595,6 +1611,7 @@ Name | Type | Description  | Notes
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -1678,6 +1695,7 @@ void (empty response body)
 | **400** | Bad Request |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -1761,6 +1779,7 @@ Name | Type | Description  | Notes
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -1843,6 +1862,7 @@ Name | Type | Description  | Notes
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -1927,6 +1947,7 @@ Name | Type | Description  | Notes
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -2008,6 +2029,7 @@ Name | Type | Description  | Notes
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -2088,6 +2110,7 @@ Name | Type | Description  | Notes
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -2164,6 +2187,7 @@ This endpoint does not need any parameter.
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -2247,6 +2271,7 @@ Name | Type | Description  | Notes
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -2330,12 +2355,13 @@ Name | Type | Description  | Notes
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
 <a name="getnotifications"></a>
 # **GetNotifications**
-> NotificationSlice GetNotifications (string appId, int? limit = null, int? offset = null, int? kind = null)
+> NotificationSlice GetNotifications (string appId, int? limit = null, int? offset = null, int? kind = null, string timeOffset = null)
 
 View notifications
 
@@ -2365,11 +2391,12 @@ namespace Example
             var limit = 10;  // int? | How many notifications to return.  Max is 50.  Default is 50. (optional) 
             var offset = 0;  // int? | Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional) 
             var kind = 0;  // int? | Kind of notifications returned:   * unset - All notification types (default)   * `0` - Dashboard only   * `1` - API only   * `3` - Automated only  (optional) 
+            var timeOffset = "2025-01-01T00:00:00.000Z";  // string | Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. `2025-01-01T00:00:00.000Z`) or the opaque Base64 cursor token returned as `next_time_offset` in a prior response.  When set, results are sorted ascending by send_after and the standard `offset` parameter cannot be used.  Repeat the request with each `next_time_offset` until an empty notifications array is returned. (optional) 
 
             try
             {
                 // View notifications
-                NotificationSlice result = apiInstance.GetNotifications(appId, limit, offset, kind);
+                NotificationSlice result = apiInstance.GetNotifications(appId, limit, offset, kind, timeOffset);
                 Debug.WriteLine(result);
             }
             catch (ApiException  e)
@@ -2395,6 +2422,7 @@ Name | Type | Description  | Notes
  **limit** | **int?**| How many notifications to return.  Max is 50.  Default is 50. | [optional] 
  **offset** | **int?**| Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. | [optional] 
  **kind** | **int?**| Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  | [optional] 
+ **timeOffset** | **string**| Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. | [optional] 
 
 ### Return type
 
@@ -2416,6 +2444,7 @@ Name | Type | Description  | Notes
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -2506,6 +2535,7 @@ Name | Type | Description  | Notes
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -2590,6 +2620,7 @@ Name | Type | Description  | Notes
 | **201** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -2674,6 +2705,7 @@ Name | Type | Description  | Notes
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -2755,6 +2787,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -2839,6 +2872,7 @@ Name | Type | Description  | Notes
 | **201** | Created |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -2924,6 +2958,7 @@ Name | Type | Description  | Notes
 | **404** | Not Found |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -3008,6 +3043,7 @@ Name | Type | Description  | Notes
 | **202** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -3091,6 +3127,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -3173,6 +3210,7 @@ Name | Type | Description  | Notes
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -3257,6 +3295,7 @@ Name | Type | Description  | Notes
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -3341,6 +3380,7 @@ void (empty response body)
 | **404** | Not Found |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -3427,6 +3467,7 @@ Name | Type | Description  | Notes
 | **202** | ACCEPTED |  -  |
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -3510,6 +3551,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -3596,6 +3638,7 @@ Name | Type | Description  | Notes
 | **400** | Bad Request |  -  |
 | **409** | Conflict |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -3675,6 +3718,7 @@ Name | Type | Description  | Notes
 |-------------|-------------|------------------|
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -3757,6 +3801,7 @@ Name | Type | Description  | Notes
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **404** | Not Found |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 
@@ -3843,6 +3888,7 @@ Name | Type | Description  | Notes
 | **200** | OK |  -  |
 | **400** | Bad Request |  -  |
 | **429** | Rate Limit Exceeded |  -  |
+| **0** | Unexpected error |  -  |
 
 [[Back to top]](#) [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)
 

--- a/docs/NotificationSlice.md
+++ b/docs/NotificationSlice.md
@@ -7,6 +7,8 @@ Name | Type | Description | Notes
 **TotalCount** | **int** |  | [optional] 
 **Offset** | **int** |  | [optional] 
 **Limit** | **int** |  | [optional] 
+**TimeOffset** | **string** | The time_offset cursor specified in the request, if any. | [optional] 
+**NextTimeOffset** | **string** | An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating. | [optional] 
 **Notifications** | [**List&lt;NotificationWithMeta&gt;**](NotificationWithMeta.md) |  | [optional] 
 
 [[Back to API list]](https://github.com/OneSignal/onesignal-dotnet-api#full-api-reference) [[Back to README]](https://github.com/OneSignal/onesignal-dotnet-api)

--- a/src/OneSignalApi/Api/DefaultApi.cs
+++ b/src/OneSignalApi/Api/DefaultApi.cs
@@ -696,9 +696,10 @@ namespace OneSignalApi.Api
         /// <param name="limit">How many notifications to return.  Max is 50.  Default is 50. (optional)</param>
         /// <param name="offset">Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)</param>
         /// <param name="kind">Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  (optional)</param>
+        /// <param name="timeOffset">Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>NotificationSlice</returns>
-        NotificationSlice GetNotifications(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), int operationIndex = 0);
+        NotificationSlice GetNotifications(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), string timeOffset = default(string), int operationIndex = 0);
 
         /// <summary>
         /// View notifications
@@ -711,9 +712,10 @@ namespace OneSignalApi.Api
         /// <param name="limit">How many notifications to return.  Max is 50.  Default is 50. (optional)</param>
         /// <param name="offset">Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)</param>
         /// <param name="kind">Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  (optional)</param>
+        /// <param name="timeOffset">Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of NotificationSlice</returns>
-        ApiResponse<NotificationSlice> GetNotificationsWithHttpInfo(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), int operationIndex = 0);
+        ApiResponse<NotificationSlice> GetNotificationsWithHttpInfo(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), string timeOffset = default(string), int operationIndex = 0);
         /// <summary>
         /// View Outcomes
         /// </summary>
@@ -1905,10 +1907,11 @@ namespace OneSignalApi.Api
         /// <param name="limit">How many notifications to return.  Max is 50.  Default is 50. (optional)</param>
         /// <param name="offset">Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)</param>
         /// <param name="kind">Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  (optional)</param>
+        /// <param name="timeOffset">Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of NotificationSlice</returns>
-        System.Threading.Tasks.Task<NotificationSlice> GetNotificationsAsync(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<NotificationSlice> GetNotificationsAsync(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), string timeOffset = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
 
         /// <summary>
         /// View notifications
@@ -1921,10 +1924,11 @@ namespace OneSignalApi.Api
         /// <param name="limit">How many notifications to return.  Max is 50.  Default is 50. (optional)</param>
         /// <param name="offset">Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)</param>
         /// <param name="kind">Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  (optional)</param>
+        /// <param name="timeOffset">Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (NotificationSlice)</returns>
-        System.Threading.Tasks.Task<ApiResponse<NotificationSlice>> GetNotificationsWithHttpInfoAsync(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
+        System.Threading.Tasks.Task<ApiResponse<NotificationSlice>> GetNotificationsWithHttpInfoAsync(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), string timeOffset = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken));
         /// <summary>
         /// View Outcomes
         /// </summary>
@@ -7142,11 +7146,12 @@ namespace OneSignalApi.Api
         /// <param name="limit">How many notifications to return.  Max is 50.  Default is 50. (optional)</param>
         /// <param name="offset">Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)</param>
         /// <param name="kind">Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  (optional)</param>
+        /// <param name="timeOffset">Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>NotificationSlice</returns>
-        public NotificationSlice GetNotifications(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), int operationIndex = 0)
+        public NotificationSlice GetNotifications(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), string timeOffset = default(string), int operationIndex = 0)
         {
-            OneSignalApi.Client.ApiResponse<NotificationSlice> localVarResponse = GetNotificationsWithHttpInfo(appId, limit, offset, kind);
+            OneSignalApi.Client.ApiResponse<NotificationSlice> localVarResponse = GetNotificationsWithHttpInfo(appId, limit, offset, kind, timeOffset);
             return localVarResponse.Data;
         }
 
@@ -7158,9 +7163,10 @@ namespace OneSignalApi.Api
         /// <param name="limit">How many notifications to return.  Max is 50.  Default is 50. (optional)</param>
         /// <param name="offset">Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)</param>
         /// <param name="kind">Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  (optional)</param>
+        /// <param name="timeOffset">Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <returns>ApiResponse of NotificationSlice</returns>
-        public OneSignalApi.Client.ApiResponse<NotificationSlice> GetNotificationsWithHttpInfo(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), int operationIndex = 0)
+        public OneSignalApi.Client.ApiResponse<NotificationSlice> GetNotificationsWithHttpInfo(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), string timeOffset = default(string), int operationIndex = 0)
         {
             // verify the required parameter 'appId' is set
             if (appId == null)
@@ -7202,6 +7208,10 @@ namespace OneSignalApi.Api
             if (kind != null)
             {
                 localVarRequestOptions.QueryParameters.Add(OneSignalApi.Client.ClientUtils.ParameterToMultiMap("", "kind", kind));
+            }
+            if (timeOffset != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(OneSignalApi.Client.ClientUtils.ParameterToMultiMap("", "time_offset", timeOffset));
             }
 
             localVarRequestOptions.Operation = "DefaultApi.GetNotifications";
@@ -7236,12 +7246,13 @@ namespace OneSignalApi.Api
         /// <param name="limit">How many notifications to return.  Max is 50.  Default is 50. (optional)</param>
         /// <param name="offset">Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)</param>
         /// <param name="kind">Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  (optional)</param>
+        /// <param name="timeOffset">Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of NotificationSlice</returns>
-        public async System.Threading.Tasks.Task<NotificationSlice> GetNotificationsAsync(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<NotificationSlice> GetNotificationsAsync(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), string timeOffset = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
-            OneSignalApi.Client.ApiResponse<NotificationSlice> localVarResponse = await GetNotificationsWithHttpInfoAsync(appId, limit, offset, kind, operationIndex, cancellationToken).ConfigureAwait(false);
+            OneSignalApi.Client.ApiResponse<NotificationSlice> localVarResponse = await GetNotificationsWithHttpInfoAsync(appId, limit, offset, kind, timeOffset, operationIndex, cancellationToken).ConfigureAwait(false);
             return localVarResponse.Data;
         }
 
@@ -7253,10 +7264,11 @@ namespace OneSignalApi.Api
         /// <param name="limit">How many notifications to return.  Max is 50.  Default is 50. (optional)</param>
         /// <param name="offset">Page offset.  Default is 0.  Results are sorted by queued_at in descending order.  queued_at is a representation of the time that the notification was queued at. (optional)</param>
         /// <param name="kind">Kind of notifications returned:   * unset - All notification types (default)   * &#x60;0&#x60; - Dashboard only   * &#x60;1&#x60; - API only   * &#x60;3&#x60; - Automated only  (optional)</param>
+        /// <param name="timeOffset">Time-offset pagination cursor for sequential pulls of all messages.  Accepts either an ISO 8601 formatted timestamp (e.g. &#x60;2025-01-01T00:00:00.000Z&#x60;) or the opaque Base64 cursor token returned as &#x60;next_time_offset&#x60; in a prior response.  When set, results are sorted ascending by send_after and the standard &#x60;offset&#x60; parameter cannot be used.  Repeat the request with each &#x60;next_time_offset&#x60; until an empty notifications array is returned. (optional)</param>
         /// <param name="operationIndex">Index associated with the operation.</param>
         /// <param name="cancellationToken">Cancellation Token to cancel the request.</param>
         /// <returns>Task of ApiResponse (NotificationSlice)</returns>
-        public async System.Threading.Tasks.Task<OneSignalApi.Client.ApiResponse<NotificationSlice>> GetNotificationsWithHttpInfoAsync(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
+        public async System.Threading.Tasks.Task<OneSignalApi.Client.ApiResponse<NotificationSlice>> GetNotificationsWithHttpInfoAsync(string appId, int? limit = default(int?), int? offset = default(int?), int? kind = default(int?), string timeOffset = default(string), int operationIndex = 0, System.Threading.CancellationToken cancellationToken = default(System.Threading.CancellationToken))
         {
             // verify the required parameter 'appId' is set
             if (appId == null)
@@ -7299,6 +7311,10 @@ namespace OneSignalApi.Api
             if (kind != null)
             {
                 localVarRequestOptions.QueryParameters.Add(OneSignalApi.Client.ClientUtils.ParameterToMultiMap("", "kind", kind));
+            }
+            if (timeOffset != null)
+            {
+                localVarRequestOptions.QueryParameters.Add(OneSignalApi.Client.ClientUtils.ParameterToMultiMap("", "time_offset", timeOffset));
             }
 
             localVarRequestOptions.Operation = "DefaultApi.GetNotifications";

--- a/src/OneSignalApi/Client/NotificationHelpers.cs
+++ b/src/OneSignalApi/Client/NotificationHelpers.cs
@@ -116,6 +116,33 @@ namespace OneSignalApi.Client
             }
         }
 
+        /// <summary>
+        /// Whether a POST /notifications 200 response is the "message sent"
+        /// branch. POST /notifications returns 200 in two cases that share the
+        /// <see cref="CreateNotificationSuccessResponse"/> shape: a notification
+        /// was created (non-empty <c>Id</c>), or none was (empty <c>Id</c>, with
+        /// <c>Errors</c> carrying the reason). Prefer this guard over inspecting
+        /// <c>Id</c> directly.
+        /// </summary>
+        /// <param name="response">A create-notification success response.</param>
+        /// <returns>True when a notification was created.</returns>
+        public static bool IsMessageSent(CreateNotificationSuccessResponse response)
+        {
+            return response != null && !string.IsNullOrEmpty(response.Id);
+        }
+
+        /// <summary>
+        /// Whether a POST /notifications 200 response is the "message not sent"
+        /// branch -- no notification was created (<c>Id</c> absent or empty);
+        /// inspect <c>Errors</c> for why.
+        /// </summary>
+        /// <param name="response">A create-notification success response.</param>
+        /// <returns>True when no notification was created.</returns>
+        public static bool IsMessageNotSent(CreateNotificationSuccessResponse response)
+        {
+            return !IsMessageSent(response);
+        }
+
         private static string HeaderValue(Multimap<string, string> headers, string name)
         {
             if (headers == null)

--- a/src/OneSignalApi/Model/CreateNotificationSuccessResponse.cs
+++ b/src/OneSignalApi/Model/CreateNotificationSuccessResponse.cs
@@ -35,7 +35,7 @@ namespace OneSignalApi.Model
         /// <summary>
         /// Initializes a new instance of the <see cref="CreateNotificationSuccessResponse" /> class.
         /// </summary>
-        /// <param name="id">Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200)..</param>
+        /// <param name="id">Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly..</param>
         /// <param name="externalId">Optional correlation / idempotency-related value from the API response. This is not the end-user External ID used for targeting recipients (that lives under &#x60;include_aliases.external_id&#x60;)..</param>
         /// <param name="errors">Polymorphic field: may be an array of human-readable strings and/or an object (for example with &#x60;invalid_aliases&#x60;, &#x60;invalid_external_user_ids&#x60;, or &#x60;invalid_player_ids&#x60;) depending on the API response; HTTP may still be 200 with partial success. Typed SDKs model this loosely so both shapes deserialize..</param>
         public CreateNotificationSuccessResponse(string id = default(string), string externalId = default(string), Object errors = default(Object))
@@ -46,9 +46,9 @@ namespace OneSignalApi.Model
         }
 
         /// <summary>
-        /// Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200).
+        /// Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly.
         /// </summary>
-        /// <value>Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200).</value>
+        /// <value>Notification identifier when the request created a notification. An empty string means no notification was created; read &#x60;errors&#x60; for details (HTTP may still be 200). All OneSignal server SDKs expose message-sent / message-not-sent narrowing helpers (named idiomatically per language — e.g. &#x60;isMessageSent&#x60;, &#x60;is_message_sent&#x60;, &#x60;message_sent?&#x60;); prefer them over comparing &#x60;id&#x60; directly.</value>
         [DataMember(Name = "id", EmitDefaultValue = false)]
         public string Id { get; set; }
 

--- a/src/OneSignalApi/Model/NotificationSlice.cs
+++ b/src/OneSignalApi/Model/NotificationSlice.cs
@@ -38,12 +38,16 @@ namespace OneSignalApi.Model
         /// <param name="totalCount">totalCount.</param>
         /// <param name="offset">offset.</param>
         /// <param name="limit">limit.</param>
+        /// <param name="timeOffset">The time_offset cursor specified in the request, if any..</param>
+        /// <param name="nextTimeOffset">An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating..</param>
         /// <param name="notifications">notifications.</param>
-        public NotificationSlice(int totalCount = default(int), int offset = default(int), int limit = default(int), List<NotificationWithMeta> notifications = default(List<NotificationWithMeta>))
+        public NotificationSlice(int totalCount = default(int), int offset = default(int), int limit = default(int), string timeOffset = default(string), string nextTimeOffset = default(string), List<NotificationWithMeta> notifications = default(List<NotificationWithMeta>))
         {
             this.TotalCount = totalCount;
             this.Offset = offset;
             this.Limit = limit;
+            this.TimeOffset = timeOffset;
+            this.NextTimeOffset = nextTimeOffset;
             this.Notifications = notifications;
         }
 
@@ -66,6 +70,20 @@ namespace OneSignalApi.Model
         public int Limit { get; set; }
 
         /// <summary>
+        /// The time_offset cursor specified in the request, if any.
+        /// </summary>
+        /// <value>The time_offset cursor specified in the request, if any.</value>
+        [DataMember(Name = "time_offset", EmitDefaultValue = false)]
+        public string TimeOffset { get; set; }
+
+        /// <summary>
+        /// An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating.
+        /// </summary>
+        /// <value>An opaque Base64 cursor token representing the next page of messages to fetch.  Present when time_offset was provided in the request.  Pass this value as time_offset on the next request to continue paginating.</value>
+        [DataMember(Name = "next_time_offset", EmitDefaultValue = false)]
+        public string NextTimeOffset { get; set; }
+
+        /// <summary>
         /// Gets or Sets Notifications
         /// </summary>
         [DataMember(Name = "notifications", EmitDefaultValue = false)]
@@ -82,6 +100,8 @@ namespace OneSignalApi.Model
             sb.Append("  TotalCount: ").Append(TotalCount).Append("\n");
             sb.Append("  Offset: ").Append(Offset).Append("\n");
             sb.Append("  Limit: ").Append(Limit).Append("\n");
+            sb.Append("  TimeOffset: ").Append(TimeOffset).Append("\n");
+            sb.Append("  NextTimeOffset: ").Append(NextTimeOffset).Append("\n");
             sb.Append("  Notifications: ").Append(Notifications).Append("\n");
             sb.Append("}\n");
             return sb.ToString();
@@ -131,6 +151,16 @@ namespace OneSignalApi.Model
                     this.Limit.Equals(input.Limit)
                 ) && 
                 (
+                    this.TimeOffset == input.TimeOffset ||
+                    (this.TimeOffset != null &&
+                    this.TimeOffset.Equals(input.TimeOffset))
+                ) && 
+                (
+                    this.NextTimeOffset == input.NextTimeOffset ||
+                    (this.NextTimeOffset != null &&
+                    this.NextTimeOffset.Equals(input.NextTimeOffset))
+                ) && 
+                (
                     this.Notifications == input.Notifications ||
                     this.Notifications != null &&
                     input.Notifications != null &&
@@ -150,6 +180,14 @@ namespace OneSignalApi.Model
                 hashCode = (hashCode * 59) + this.TotalCount.GetHashCode();
                 hashCode = (hashCode * 59) + this.Offset.GetHashCode();
                 hashCode = (hashCode * 59) + this.Limit.GetHashCode();
+                if (this.TimeOffset != null)
+                {
+                    hashCode = (hashCode * 59) + this.TimeOffset.GetHashCode();
+                }
+                if (this.NextTimeOffset != null)
+                {
+                    hashCode = (hashCode * 59) + this.NextTimeOffset.GetHashCode();
+                }
                 if (this.Notifications != null)
                 {
                     hashCode = (hashCode * 59) + this.Notifications.GetHashCode();


### PR DESCRIPTION
## Release v5.8.0

### 🚀 Features
- feat: [SDK-4440] generate typed error-code catalog module per SDK
- feat: [SDK-4441] add idempotency-key retry helper for create-notification
- feat: [SDK-4441] expose createNotificationWithRetry as a client method
- feat: [SDK-4441] clamp retry helper backoff base to [1s, 60s]
- feat: [SDK-4776] expose time_offset pagination on get_notifications
- feat: [SDK-4781] add message-sent/not-sent narrowing helpers
- feat: [SDK-4781] refine narrowing-helper doc nudge and PHP null-safety
- feat: [SDK-4790] declare default error responses for all operations

### 🐛 Bug Fixes
- fix: [SDK-4438] guard C++/C# errorMessages against non-string title
- fix: [SDK-4438] skip null and non-string items in C# ErrorMessages
- fix: [SDK-4440] reclassify OVER_SUBSCRIBER_LIMIT as a template entry
- fix: [SDK-4438] treat empty title as missing in all error-messages accessors
- fix: [SDK-4438] surface object-shaped errors in error-messages accessors
- fix: [SDK-4440] trim OneSignalErrors catalog to a verified minimal set
- fix: [SDK-4776] append time_offset after kind in get_notifications

### 📚 Docs
- docs: [SDK-4441] add createNotificationWithRetry example to DefaultApi docs
- docs: [SDK-4440] fix OneSignalErrors usage example for the 200-status sentinel
- docs: clarify errorMessages excludes structured meta; show how to read it
- docs: demonstrate reading 409 conflict meta in CreateUser example
- docs: [SDK-4440] cross-link OneSignalErrors catalog from DefaultApi.md error handling

---
_Generated from [OneSignal/api-client-libraries@e4fc576...09ec934](https://github.com/OneSignal/api-client-libraries/compare/e4fc576245a3346beb6b5edb89ad0ccb03dfa655...09ec934ab3eec4c769d5dc0f3cf9ad9a3f088b26)._